### PR TITLE
add missing plugin for build bootWar

### DIFF
--- a/rt-front-web/build.gradle
+++ b/rt-front-web/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id 'java'
 	id 'eclipse'
 	id 'idea'
+	id 'org.springframework.boot' version "2.0.3.RELEASE"
 }
 
 group = "${rootProject.group}"


### PR DESCRIPTION
为了可以在项目里用 gradle rt-front-web:build 来打包生成可以直接执行的 war， 需要增加 gradle 的 springboot 插件。
但是由于 gradle 在 plugins block 中是不支持变量引用的。。。。。。 所以先用了硬编码的方法。虽然 ugly，但是至少可以打出包来了。